### PR TITLE
fix: deploy docs from build output directory

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -36,5 +36,5 @@ jobs:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          working-directory: ./docs
+          working-directory: ./docs/out
           vercel-args: '--prod'


### PR DESCRIPTION
Fix 404 errors by deploying from ./docs/out (where Next.js static export generates files) instead of ./docs source directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Description
<!-- Provide a brief description of the changes in this PR -->

## Type of Change
<!-- Please check the relevant option -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Related Issues
<!-- Link to any related issues -->
Fixes #(issue number)

## Changes Made
<!-- List the main changes made in this PR -->
- 
- 
- 

## Testing
<!-- Describe how you tested your changes -->
- [ ] I have tested the changes locally
- [ ] The build passes without errors
- [ ] I have added/updated tests if applicable
- [ ] Examples still work with these changes

## Checklist
<!-- Please check all that apply -->
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Screenshots/Examples
<!-- If applicable, add screenshots or code examples to help explain your changes -->

## Additional Notes
<!-- Add any additional information that reviewers should know -->
